### PR TITLE
Replace memory icon with a nerd font compatible one

### DIFF
--- a/.config/fastfetch/config.jsonc
+++ b/.config/fastfetch/config.jsonc
@@ -81,7 +81,7 @@
     // },
     {
       "type": "memory",
-      "key": "󰍛 ",
+      "key": " ",
       "keyColor": "cyan"
     },
     {

--- a/.config/i3status/config
+++ b/.config/i3status/config
@@ -18,7 +18,7 @@ load {
 }
 
 memory {
-    format = "   %used / %total "      
+    format = "   %used / %total "      
 }
 
 disk "/" {

--- a/.config/neofetch/config.conf
+++ b/.config/neofetch/config.conf
@@ -21,7 +21,7 @@ print_info() {
     info " " cpu
     info " " gpu
 
-    info "󰍛 " memory
+    info " " memory
     info " " disk
 
     info "󱫐 " uptime

--- a/.config/starship/starship.toml
+++ b/.config/starship/starship.toml
@@ -96,7 +96,7 @@ symbol = " "
 symbol = " "
 
 [memory_usage]
-symbol = "󰍛 "
+symbol = " "
 
 [meson]
 symbol = "󰔷 "

--- a/.config/waybar/bak/og/config.jsonc.bak
+++ b/.config/waybar/bak/og/config.jsonc.bak
@@ -133,7 +133,7 @@
   },
   "memory": {
     "interval": 1,
-    "format": " {}%",
+    "format": " {}%",
     "tooltip-format": "{used}/{total} GiB",
     "on-click": "swaymsg exec gnome-system-monitor"
   },

--- a/.config/waybar/bak/omarch-mod/config.jsonc
+++ b/.config/waybar/bak/omarch-mod/config.jsonc
@@ -146,7 +146,7 @@
   },
   "memory": {
     "interval": 1,
-    "format": " {}%",
+    "format": " {}%",
     "tooltip-format": "{used}/{total} GiB",
     "on-click": "swaymsg exec gnome-system-monitor"
   },

--- a/.config/waybar/bak/omarch/config.jsonc
+++ b/.config/waybar/bak/omarch/config.jsonc
@@ -115,7 +115,7 @@
   },
   "memory": {
     "interval": 1,
-    "format": " {}%",
+    "format": " {}%",
     "tooltip-format": "{used}/{total} GiB",
     "on-click": "swaymsg exec gnome-system-monitor"
   },

--- a/.config/waybar/config.jsonc
+++ b/.config/waybar/config.jsonc
@@ -168,7 +168,7 @@
   },
   "memory": {
     "interval": 1,
-    "format": " {}%",
+    "format": " {}%",
     "tooltip-format": "{used}/{total} GiB",
     "on-click": "swaymsg exec gnome-system-monitor"
   },


### PR DESCRIPTION
Hello, I used your wonderful theme, but noticed a slight detail. The icon for my memory did not load. On further investigation i found that it is probably a custom icon? (I did not read the manuals of this repo) I did some searching and found that nerd fonts has an icon for ram (search  for memory in [Nerd Font cheat sheet](https://www.nerdfonts.com/cheat-sheet)). I thought why not contribute to this project, so I did.

If you don't like the icon or have some other reason feel free to reject this PR.